### PR TITLE
Add no-cpu-culling to bevy_city

### DIFF
--- a/src/bin/collect.rs
+++ b/src/bin/collect.rs
@@ -293,7 +293,7 @@ impl Commands {
                         )),
                         Box::new(large_scenes::LargeScene::on(
                             "bevy_city".to_string(),
-                            vec![],
+                            vec![("no-cpu-culling".into(), None)],
                             25000,
                         )),
                     ]


### PR DESCRIPTION
The `NoCpuCulling` component was optimized specifically for this scene so we should track it's performance.