### PR TITLE
kill a single running stress tests / large scene after 2hours

### DIFF
--- a/src/metrics/large_scenes.rs
+++ b/src/metrics/large_scenes.rs
@@ -10,6 +10,8 @@ use xshell::{Shell, cmd};
 
 use crate::Metrics;
 
+const RUN_TIMEOUT_SECS: u64 = 7200;
+
 #[derive(Debug)]
 pub struct LargeScene {
     pub scene: String,
@@ -153,21 +155,29 @@ impl Metrics for LargeScene {
 
         let _scale_guard = sh.push_env("WINIT_X11_SCALE_FACTOR", "1");
 
+        let timeout = super::run_timeout_secs(RUN_TIMEOUT_SECS).to_string();
         let cmd = cmd!(
             sh,
-            "mangohud cargo run --release {features...} --package {scene} -- {parameters...}"
+            "timeout --kill-after=30s {timeout} mangohud cargo run --release {features...} --package {scene} -- {parameters...}"
         );
         let mut results = HashMap::new();
 
         let start = Instant::now();
         let cmd_result = cmd.run();
 
+        if cmd_result.is_err() {
+            let pattern = format!("target/release/{scene}");
+            let _ = cmd!(sh, "pkill -9 -f {pattern}").run();
+        }
+
         let _ = cmd!(sh, "sudo systemctl stop lightdm").run();
         thread::sleep(Duration::from_secs(5));
         let _ = cmd!(sh, "sudo /usr/local/sbin/pin.sh unlock").run();
 
-        if cmd_result.is_err() {
-            // ignore failure due to a missing scene
+        if let Err(err) = cmd_result {
+            eprintln!(
+                "{key}: large scene run failed or exceeded its run cap, no metrics recorded: {err}"
+            );
             return results;
         };
         let elapsed = start.elapsed();

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -58,6 +58,13 @@ pub(crate) fn parse_mangohud_csv(path: &std::path::Path) -> Vec<MangohudSample> 
         .collect()
 }
 
+pub(crate) fn run_timeout_secs(default: u64) -> u64 {
+    std::env::var("TWITCHER_RUN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
 pub mod benchmarks;
 pub mod binary_size;
 pub mod compile_time;

--- a/src/metrics/stress_tests.rs
+++ b/src/metrics/stress_tests.rs
@@ -10,6 +10,8 @@ use xshell::{Shell, cmd};
 
 use crate::Metrics;
 
+const RUN_TIMEOUT_SECS: u64 = 7200;
+
 #[derive(Debug)]
 pub struct StressTest {
     pub stress_test: String,
@@ -135,21 +137,29 @@ impl Metrics for StressTest {
 
         let _scale_guard = sh.push_env("WINIT_X11_SCALE_FACTOR", "1");
 
+        let timeout = super::run_timeout_secs(RUN_TIMEOUT_SECS).to_string();
         let cmd = cmd!(
             sh,
-            "mangohud cargo run --release {features...} --example {stress_tests} -- {parameters...}"
+            "timeout --kill-after=30s {timeout} mangohud cargo run --release {features...} --example {stress_tests} -- {parameters...}"
         );
         let mut results = HashMap::new();
 
         let start = Instant::now();
         let cmd_result = cmd.run();
 
+        if cmd_result.is_err() {
+            let pattern = format!("target/release/examples/{stress_tests}");
+            let _ = cmd!(sh, "pkill -9 -f {pattern}").run();
+        }
+
         let _ = cmd!(sh, "sudo systemctl stop lightdm").run();
         thread::sleep(Duration::from_secs(5));
         let _ = cmd!(sh, "sudo /usr/local/sbin/pin.sh unlock").run();
 
-        if cmd_result.is_err() {
-            // ignore failure due to a missing scene
+        if let Err(err) = cmd_result {
+            eprintln!(
+                "{key}: stress test run failed or exceeded its run cap, no metrics recorded: {err}"
+            );
             return results;
         };
         let elapsed = start.elapsed();


### PR DESCRIPTION
long enough to be noticeable in monitoring